### PR TITLE
Add player list for protected planets

### DIFF
--- a/config/config.json.default
+++ b/config/config.json.default
@@ -108,6 +108,7 @@
                 "spinningrocket",
                 "stationaryrocket"
             ],
+            "player_planets": {},
             "protected_planets": []
         },
         "player_manager": {

--- a/plugins/planet_protect/planet_protect_plugin.py
+++ b/plugins/planet_protect/planet_protect_plugin.py
@@ -10,7 +10,7 @@ class PlanetProtectPlugin(SimpleCommandPlugin):
     """
     name = "planet_protect"
     description = "Protects planets."
-    commands = ["protect", "unprotect"]
+    commands = ["protect", "unprotect", "protect_list"]
     depends = ["player_manager", "command_dispatcher"]
 
     def activate(self):
@@ -24,24 +24,40 @@ class PlanetProtectPlugin(SimpleCommandPlugin):
             "DAMAGE_TILE",
             "DAMAGE_TILE_GROUP",
             "REQUEST_DROP",
+            "ENTITY_INTERACT",
             "MODIFY_TILE_LIST"]
         for n in ["on_" + n.lower() for n in bad_packets]:
             setattr(self, n, (lambda x: self.planet_check()))
         self.protected_planets = self.config.plugin_config.get("protected_planets", [])
+        self.player_planets = self.config.plugin_config.get("player_planets", {})
         self.blacklist = self.config.plugin_config.get("blacklist", [])
         self.player_manager = self.plugins.get("player_manager", [])
 
     def planet_check(self):
-        if not self.protocol.player.on_ship and self.protocol.player.planet in self.protected_planets and self.protocol.player.access_level < UserLevels.REGISTERED:
-            return False
+        if self.protocol.player.planet in self.protected_planets and self.protocol.player.access_level < UserLevels.ADMIN:
+            on_ship = self.protocol.player.on_ship
+            if on_ship:
+                return True
+            else:
+                name = self.protocol.player.name
+                for self.protocol.player.planet in self.player_planets.keys():
+                    if name in self.player_planets[self.protocol.player.planet]:
+                        return True
+                    else:
+                        return False
         else:
             return True
 
     @permissions(UserLevels.ADMIN)
     def protect(self, data):
-        """Protects the current planet. Only registered users can build on protected planets. Syntax: /protect"""
+        """Protects the current planet. Only administrators can build on protected planets. Syntax: /protect"""
         planet = self.protocol.player.planet
         on_ship = self.protocol.player.on_ship
+        if len(data) == 0:
+            addplayer = self.protocol.player.name
+        else:
+            addplayer = data[0]
+        first_name = addplayer
         if on_ship:
             self.protocol.send_chat_message("Can't protect ships (at the moment)")
             return
@@ -49,24 +65,63 @@ class PlanetProtectPlugin(SimpleCommandPlugin):
             self.protected_planets.append(planet)
             self.protocol.send_chat_message("Planet successfully protected.")
             self.logger.info("Protected planet %s", planet)
+            if len(first_name) > 0:
+                if planet not in self.player_planets:
+                    self.player_planets[planet] = [first_name]
+                else:
+                    self.player_planets[planet] = self.player_planets[planet] + [first_name]
+                self.protocol.send_chat_message("Adding player to planet list: " + first_name)
         else:
-            self.protocol.send_chat_message("Planet is already protected!")
+            if len(first_name) == 0:
+                self.protocol.send_chat_message("Planet is already protected!")
+            else:
+                if planet not in self.player_planets:
+                    self.player_planets[planet] = [first_name]
+                else:
+                    self.player_planets[planet] = self.player_planets[planet] + [first_name]
+                self.protocol.send_chat_message("Adding player to planet list: " + first_name)
         self.save()
 
     @permissions(UserLevels.ADMIN)
-    def unprotect(self, data):
-        """Removes the protection from the current planet. Syntax: /unprotect"""
+    def protect_list(self, data):
+        """Lists Users registered to the protected planet. Syntax: /protect_list"""
         planet = self.protocol.player.planet
         on_ship = self.protocol.player.on_ship
         if on_ship:
             self.protocol.send_chat_message("Can't protect ships (at the moment)")
             return
-        if planet in self.protected_planets:
-            self.protected_planets.remove(planet)
-            self.protocol.send_chat_message("Planet successfully unprotected.")
-            self.logger.info("Unprotected planet %s", planet)
+        if planet in self.player_planets:
+            self.protocol.send_chat_message("Players registered to this planet: " + str(self.player_planets[planet]).strip('[]'))
         else:
             self.protocol.send_chat_message("Planet is not protected!")
+
+    @permissions(UserLevels.ADMIN)
+    def unprotect(self, data):
+        """Removes the protection from the current planet, or removes a registered player. Syntax: /unprotect <user>"""
+        planet = self.protocol.player.planet
+        on_ship = self.protocol.player.on_ship
+        if len(data) == 0:
+            addplayer = self.protocol.player.name
+        else:
+            addplayer = data[0]
+        first_name = addplayer
+        if on_ship:
+            self.protocol.send_chat_message("Can't protect ships (at the moment)")
+            return
+        if len(data) == 0:
+            if planet in self.protected_planets:
+                del self.player_planets[planet]
+                self.protected_planets.remove(planet)
+                self.protocol.send_chat_message("Planet successfully unprotected.")
+                self.logger.info("Unprotected planet %s", planet)
+            else:
+                self.protocol.send_chat_message("Planet is not protected!")
+        else:
+            if first_name in self.player_planets[planet]:
+                self.player_planets[planet].remove(first_name)
+                self.protocol.send_chat_message("Removed " + first_name + "from planet")
+            else:
+                self.protocol.send_chat_message("Cannot remove " + first_name + "from planet--Not registered")
         self.save()
 
     def save(self):


### PR DESCRIPTION
Changes protection to only permit ADMIN or higher;
Allows the ability to add a player/username (case sensitive) to a
planet--they are ignored by the protection--/protect <username>
Allow removal of user from planet list--/unprotect <username>
Lists current registered users on that planet /protect_list

Added value to default config to store player names with planets