### PR TITLE
Fix chat colors

### DIFF
--- a/plugins/core/__init__.py
+++ b/plugins/core/__init__.py
@@ -1,5 +1,5 @@
 from command_plugin import *
 from admin_commands_plugin import *
-from command_plugin import *
+from colored_names import *
 from player_manager import *
 from starbound_config_manager import *


### PR DESCRIPTION
command_plugin imported twice, but colored_names was not imported
