### PR TITLE
fix bug that caused all plugins to be activated twice on startup

### DIFF
--- a/server.py
+++ b/server.py
@@ -537,7 +537,6 @@ class StarryPyServerFactory(ServerFactory):
         except FatalPluginError:
             logger.critical("Shutting Down.")
             sys.exit()
-        self.plugin_manager.activate_plugins()
         self.reaper = LoopingCall(self.reap_dead_protocols)
         self.reaper.start(self.config.reap_time)
         logger.debug("Factory created, endpoint of port %d" % self.config.bind_port)


### PR DESCRIPTION
activate_plugins() is called from [PluginManager load_plugins](https://github.com/CarrotsAreMediocre/StarryPy/blob/16e002246a8daa4148a2f62f71d5aeeeb0105562/plugin_manager.py#L121), activating them in server.py was causing activate to be called on all plugins a second time when the server started,  causing db locks and possibly other nastiness.
