### PR TITLE
reworks the UDP proxy to be a plugin

### DIFF
--- a/plugins/UDPForwarder/UDPForwarder.py
+++ b/plugins/UDPForwarder/UDPForwarder.py
@@ -1,0 +1,32 @@
+from twisted.internet import reactor
+from twisted.internet.error import CannotListenError
+from twisted.internet.protocol import DatagramProtocol
+
+from base_plugin import BasePlugin
+
+
+class UDPForwader(BasePlugin):
+    """Forwards UDP datagrams to the gameserver, mostly used for Valve's Steam style statistis queries"""
+    name = "udp_forwarder"
+    auto_activate = True
+
+    def activate(self):
+
+        super(UDPForwader, self).activate()
+        try:
+            reactor.listenUDP(self.config.bind_port, UDPProxy(self.config.upstream_hostname, self.config.upstream_port))
+            self.logger.info("Listening for UDP on port %d" % self.config.bind_port)
+        except CannotListenError:
+            self.logger.error(
+                "Could not listen on UDP port %d. Will continue running, but please note that steam statistics will be unavailable.",
+                self.factory.config.bind_port
+            )
+
+
+class UDPProxy(DatagramProtocol):
+    def __init__(self,upstream_hostname, upstream_port):
+        self.upstream_hostname = upstream_hostname
+        self.upstream_port = upstream_port
+
+    def datagramReceived(self, datagram, addr):
+        self.transport.write(datagram, (self.upstream_hostname, self.upstream_port))

--- a/plugins/UDPForwarder/__init__.py
+++ b/plugins/UDPForwarder/__init__.py
@@ -1,0 +1,1 @@
+from UDPForwarder import UDPForwader

--- a/server.py
+++ b/server.py
@@ -9,7 +9,7 @@ import datetime
 import construct
 from twisted.internet import reactor
 from twisted.internet.error import CannotListenError
-from twisted.internet.protocol import ClientFactory, ServerFactory, Protocol, connectionDone, DatagramProtocol
+from twisted.internet.protocol import ClientFactory, ServerFactory, Protocol, connectionDone
 from construct import Container
 import construct.core
 from twisted.internet.task import LoopingCall
@@ -602,11 +602,6 @@ class StarboundClientFactory(ClientFactory):
         protocol.server_protocol = self.server_protocol
         return protocol
 
-
-class UDPProxy(DatagramProtocol):
-    def datagramReceived(self, datagram, addr):
-        self.transport.write(datagram, (self.config.upstream_hostname, self.config.upstream_port))
-
 if __name__ == '__main__':
     logger = logging.getLogger('starrypy')
     logger.setLevel(9)
@@ -658,10 +653,4 @@ if __name__ == '__main__':
         logger.critical("Cannot listen on TCP port %d. Exiting.", factory.config.bind_port)
         sys.exit()
     logger.info("Listening on port %s" % factory.config.bind_port)
-    try:
-        reactor.listenUDP(config.bind_port, UDPProxy())
-    except CannotListenError:
-        logger.error(
-            "Could not listen on UDP port %d. Will continue running, but please note that steam statistics will be unavailable.",
-            factory.config.bind_port)
     reactor.run()


### PR DESCRIPTION
to test use something like `ruby -e 'print([-1].pack("C")*4 + [0x54].pack("C")); print("Source Engine Query\0");' | nc -u 127.0.0.1 21025`
