### PR TITLE
Split out web plugin from session rework

### DIFF
--- a/config/config.json.default
+++ b/config/config.json.default
@@ -161,7 +161,12 @@
         },
         "warpy_plugin": {
             "auto_activate": true
+        },
+        "web_monitor": {
+            "auto_activate": true,
+            "port": 8000
         }
+
     },
     "plugin_path": "plugins",
     "port_check": true,

--- a/plugins/web_monitor/__init__.py
+++ b/plugins/web_monitor/__init__.py
@@ -1,0 +1,1 @@
+from web_monitor_plugin import WebMonitorPlugin

--- a/plugins/web_monitor/status_controller.py
+++ b/plugins/web_monitor/status_controller.py
@@ -1,0 +1,62 @@
+import simplejson
+from twisted.web.resource import Resource
+from twisted.internet import task
+
+from server import port_check
+
+
+SERVER_HEARTBEAT_TIME = 5  # seconds
+
+
+class StatusController(Resource):
+    isLeaf = True
+
+    def __init__(self, player_manager, server_config):
+        Resource.__init__(self)
+        self.player_manager = player_manager
+        self.server_config = server_config
+        self.status = "unknown"
+        self._heartbeat_task = task.LoopingCall(self._server_heartbeat)
+        # Currently disabled, this heartbeat doesn't seem to be torn down well
+        # by the server
+        # self._heartbeat_task.start(SERVER_HEARTBEAT_TIME)
+
+    def __del__(self):
+        self.stop_heartbeat()
+
+    def stop_heartbeat(self):
+        self._heartbeat_task.stop()
+
+    def start_heartbeat(self):
+        self._heartbeat_task.start(SERVER_HEARTBEAT_TIME)
+
+    def _server_heartbeat(self):
+        if port_check(self.server_config.upstream_hostname, self.server_config.upstream_port):
+            self.status = "online"
+        else:
+            self.status = "offline"
+
+    def render_GET(self, request):
+        logged_in_players = {}
+        seen_players = {}
+
+        for player in self.player_manager.all():
+            if player.logged_in:
+                logged_in_players[player.uuid] = {
+                    'name': player.name,
+                    'access_level': player.access_level,
+                    'on_ship': player.on_ship,
+                }
+            else:
+                seen_players[player.uuid] = {
+                    'name': player.name,
+                    'access_level': player.access_level,
+                    'on_ship': player.on_ship,
+                    'last_seen': player.last_seen.strftime('%Y-%m-%d~%H-%M-%S'),
+                }
+
+        return simplejson.dumps({
+            'status': self.status,
+            'logged_in_players': logged_in_players,
+            'seen_players': seen_players,
+            })

--- a/plugins/web_monitor/web_monitor_plugin.py
+++ b/plugins/web_monitor/web_monitor_plugin.py
@@ -1,0 +1,29 @@
+from twisted.web.server import Site
+from twisted.internet import reactor
+
+from base_plugin import BasePlugin
+from status_controller import StatusController
+
+
+class WebMonitorPlugin(BasePlugin):
+    name = "web_monitor"
+    depends = ['player_manager']
+
+    def __init__(self, *args, **kwargs):
+        super(WebMonitorPlugin, self).__init__(*args, **kwargs)
+        self.web_factory = None
+
+    def activate(self):
+        super(WebMonitorPlugin, self).activate()
+        if not self.web_factory:
+            self.web_factory = Site(StatusController(self.plugins['player_manager'].player_manager, self.config))
+
+        if not getattr(self, 'web_port', None):
+            self.web_port = reactor.listenTCP(self.config.plugin_config['port'], self.web_factory)
+
+    def deactivate(self):
+        self.web_port.stopListening()
+        del self.web_port
+        del self.web_factory
+
+        self.web_factory = None


### PR DESCRIPTION
This is the web plugin, built on development branch, with the player
manager rework separated out. Note that this plugin depends on that
branch--with the old session handling, it fails to work.

Now actually pulling to development.